### PR TITLE
상품 필터링 쿼리 수정 및 배너 작업

### DIFF
--- a/src/main/generated/com/hummingbird/kr/starbuckslike/banner/domain/QBanner.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/banner/domain/QBanner.java
@@ -1,0 +1,43 @@
+package com.hummingbird.kr.starbuckslike.banner.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBanner is a Querydsl query type for Banner
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBanner extends EntityPathBase<Banner> {
+
+    private static final long serialVersionUID = 852654271L;
+
+    public static final QBanner banner = new QBanner("banner");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath image = createString("image");
+
+    public final NumberPath<Integer> seq = createNumber("seq", Integer.class);
+
+    public final StringPath url = createString("url");
+
+    public QBanner(String variable) {
+        super(Banner.class, forVariable(variable));
+    }
+
+    public QBanner(Path<? extends Banner> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBanner(PathMetadata metadata) {
+        super(Banner.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/hummingbird/kr/starbuckslike/banner/dto/QBannerDto.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/banner/dto/QBannerDto.java
@@ -1,0 +1,21 @@
+package com.hummingbird.kr.starbuckslike.banner.dto;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.hummingbird.kr.starbuckslike.banner.dto.QBannerDto is a Querydsl Projection type for BannerDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QBannerDto extends ConstructorExpression<BannerDto> {
+
+    private static final long serialVersionUID = -2139881811L;
+
+    public QBannerDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> image, com.querydsl.core.types.Expression<String> url) {
+        super(BannerDto.class, new Class<?>[]{long.class, String.class, String.class}, id, image, url);
+    }
+
+}
+

--- a/src/main/generated/com/hummingbird/kr/starbuckslike/category/dto/QCategoryListDto.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/category/dto/QCategoryListDto.java
@@ -13,8 +13,8 @@ public class QCategoryListDto extends ConstructorExpression<CategoryListDto> {
 
     private static final long serialVersionUID = 1515491247L;
 
-    public QCategoryListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> path) {
-        super(CategoryListDto.class, new Class<?>[]{long.class, String.class, String.class}, id, name, path);
+    public QCategoryListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> path, com.querydsl.core.types.Expression<String> image) {
+        super(CategoryListDto.class, new Class<?>[]{long.class, String.class, String.class, String.class}, id, name, path, image);
     }
 
 }

--- a/src/main/generated/com/hummingbird/kr/starbuckslike/product/dto/QProductListDto.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/product/dto/QProductListDto.java
@@ -13,8 +13,8 @@ public class QProductListDto extends ConstructorExpression<ProductListDto> {
 
     private static final long serialVersionUID = -351548437L;
 
-    public QProductListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<Integer> price, com.querydsl.core.types.Expression<Boolean> isNew) {
-        super(ProductListDto.class, new Class<?>[]{long.class, String.class, int.class, boolean.class}, id, name, price, isNew);
+    public QProductListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<Integer> price, com.querydsl.core.types.Expression<Boolean> isNew, com.querydsl.core.types.Expression<Boolean> isDiscounted, com.querydsl.core.types.Expression<Double> discountRate) {
+        super(ProductListDto.class, new Class<?>[]{long.class, String.class, int.class, boolean.class, boolean.class, double.class}, id, name, price, isNew, isDiscounted, discountRate);
     }
 
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/banner/domain/Banner.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/banner/domain/Banner.java
@@ -1,0 +1,31 @@
+package com.hummingbird.kr.starbuckslike.banner.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 배너 엔티티
+ * @author 허정현
+ */
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "banner")
+public class Banner {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "banner_id")
+    private Long id;
+
+    @Column(name = "banner_image" , nullable = false)
+    private String image;
+
+    @Setter
+    @Column(name = "seq" , nullable = false)
+    private Integer seq;
+
+    @Column(name = "banner_url" , nullable = true)
+    private String url;
+}

--- a/src/main/java/com/hummingbird/kr/starbuckslike/banner/dto/BannerDto.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/banner/dto/BannerDto.java
@@ -1,0 +1,26 @@
+package com.hummingbird.kr.starbuckslike.banner.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Builder
+@NoArgsConstructor
+@ToString
+public class BannerDto {
+    private Long id; // 배너 Id
+
+    private String image; // 베너 이미지 경로
+
+    private String url; // 배너 클릭 시 이동할 url
+
+    @QueryProjection
+    public BannerDto(Long id, String image, String url) {
+        this.id = id;
+        this.image = image;
+        this.url = url;
+    }
+}

--- a/src/main/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/BannerRepository.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/BannerRepository.java
@@ -1,0 +1,7 @@
+package com.hummingbird.kr.starbuckslike.banner.infrastructure;
+
+import com.hummingbird.kr.starbuckslike.banner.domain.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner,Long> {
+}

--- a/src/main/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/search/BannerSearch.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/search/BannerSearch.java
@@ -1,0 +1,11 @@
+package com.hummingbird.kr.starbuckslike.banner.infrastructure.search;
+
+import com.hummingbird.kr.starbuckslike.banner.dto.BannerDto;
+
+import java.util.List;
+
+public interface BannerSearch {
+    // 배너 seq 순서대로 조회
+    List<BannerDto> findAllBannerDto();
+
+}

--- a/src/main/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/search/BannerSearchImpl.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/search/BannerSearchImpl.java
@@ -1,0 +1,30 @@
+package com.hummingbird.kr.starbuckslike.banner.infrastructure.search;
+
+import com.hummingbird.kr.starbuckslike.banner.domain.QBanner;
+import com.hummingbird.kr.starbuckslike.banner.dto.BannerDto;
+import com.hummingbird.kr.starbuckslike.banner.dto.QBannerDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.hummingbird.kr.starbuckslike.banner.domain.QBanner.banner;
+
+@Repository
+public class BannerSearchImpl implements  BannerSearch{
+    private final JPAQueryFactory factory;
+    public BannerSearchImpl(EntityManager em) {
+        this.factory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<BannerDto> findAllBannerDto() {
+        return factory
+                .select(new QBannerDto(banner.id, banner.image, banner.url))
+                .from(banner)
+                .orderBy(banner.seq.asc())
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/domain/Category.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/domain/Category.java
@@ -33,7 +33,6 @@ public class Category {
     @Setter
     private String path; // 카테고리 경로
 
-    @Column(name = "category_image",nullable = true)
-    @Setter
+    @Column(name = "category_image", nullable = true)
     private String image; // 카테고리 이미지 경로
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/dto/CategoryListDto.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/dto/CategoryListDto.java
@@ -13,12 +13,15 @@ public class CategoryListDto {
 
     private String name; // 카테고리 이름
 
-    private String path; // 카테고리 id들의 경로
+    private String path; // 카테고리 경로
+
+    private String image; // 카테고리 이미지 경로
 
     @QueryProjection
-    public CategoryListDto(Long id, String name, String path) {
+    public CategoryListDto(Long id, String name, String path, String image) {
         this.id = id;
         this.name = name;
         this.path = path;
+        this.image = image;
     }
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearch.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearch.java
@@ -5,7 +5,9 @@ import com.hummingbird.kr.starbuckslike.category.dto.CategoryListDto;
 import java.util.List;
 
 public interface CategorySearch {
-    //  깊이==depth 안 카테고리들만 검색.  (최상위 카테고리는 0)
+    //  깊이로 카테고리 검색
     List<CategoryListDto> findCategoryByDepth(Integer depth);
 
+    // 최상위 부모 카테고리만 출력
+    List<CategoryListDto> findAllRootCategory();
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearchImpl.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearchImpl.java
@@ -2,6 +2,7 @@ package com.hummingbird.kr.starbuckslike.category.infrastructure.search;
 
 import com.hummingbird.kr.starbuckslike.category.dto.CategoryListDto;
 import com.hummingbird.kr.starbuckslike.category.dto.QCategoryListDto;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
@@ -27,10 +28,28 @@ public class CategorySearchImpl implements CategorySearch {
     @Override
     public List<CategoryListDto> findCategoryByDepth(Integer depth) {
         return queryFactory
-                .select(new QCategoryListDto(category.id, category.name, category.path))
+                .select(new QCategoryListDto(category.id, category.name, category.path, category.image))
                 .from(category)
                 .where(category.depth.eq(depth))
                 .orderBy(category.id.asc())
                 .fetch();
+    }
+
+    @Override
+    public List<CategoryListDto> findAllRootCategory() {
+        return queryFactory
+                .select(new QCategoryListDto(category.id, category.name, category.path, category.image))
+                .from(category)
+                .where(
+                        rootCondition() // 최상위 부모 카테고리만 검색
+                )
+                .orderBy(category.id.asc())
+                .fetch();
+    }
+    /**
+     * 카테고리 조회의 모든 검색조건
+     */
+    private final BooleanExpression rootCondition() {
+        return category.depth.eq(0).and(category.parent.isNull());
     }
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/config/LoadTestData.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/config/LoadTestData.java
@@ -1,6 +1,8 @@
 package com.hummingbird.kr.starbuckslike.config;
 
 
+import com.hummingbird.kr.starbuckslike.banner.domain.Banner;
+import com.hummingbird.kr.starbuckslike.banner.infrastructure.BannerRepository;
 import com.hummingbird.kr.starbuckslike.category.domain.Category;
 import com.hummingbird.kr.starbuckslike.category.infrastructure.CategoryRepository;
 import com.hummingbird.kr.starbuckslike.exhibition.domain.Exhibition;
@@ -30,19 +32,22 @@ public class LoadTestData {
             CategoryRepository categoryRepository,
             ProductRepository productRepository,
             ExhibitionRepository exhibitionRepository,
-            ExhibitionProductRepository exhibitionProductRepository
+            ExhibitionProductRepository exhibitionProductRepository,
+            BannerRepository bannerRepository
                                    ) {
         return args -> {
             /**
              * 테스트용 임시 카테고리 데이터 추가
              */
             // depth 0단계 루트 카테고리 생성
-            Category tumbler = new Category(null, "텀블러", null, 0, "" ,null);
+            Category tumbler = new Category(null, "텀블러", null, 0, "" ,
+                    "https://image.istarbucks.co.kr/upload/store/skuimg/2022/02/[9300000003591]_20220222165515488.jpg");
             tumbler = categoryRepository.save(tumbler);  // ID가 생성됨
             tumbler.setPath(String.valueOf(tumbler.getId()));  // ID를 사용하여 path 설정
             tumbler = categoryRepository.save(tumbler);  // path 업데이트
 
-            Category cup = new Category(null, "컵", null, 0, "",null);
+            Category cup = new Category(null, "컵", null, 0, "",
+                    "https://image.istarbucks.co.kr/upload/store/skuimg/2024/06/[9300000005354]_20240617142521983.jpg");
             cup = categoryRepository.save(cup);
             cup.setPath(String.valueOf(cup.getId()));
             cup = categoryRepository.save(cup);
@@ -169,9 +174,6 @@ public class LoadTestData {
                     .build()
             );
 
-
-
-
             /**
              * 가획전 테스트 데이터
              */
@@ -220,7 +222,32 @@ public class LoadTestData {
                             .product(product1) // 스탠리 고급 스테인리스 텀블러 상품 연결
                             .build()
             );
+            /**
+             * 회원 테스트 데이터
+             */
 
+
+            /**
+             * 배너 테스트 데이터
+             */
+            bannerRepository.save(
+                    Banner.builder()
+                            .image("??/??/bannerImg3.jpg")
+                            .seq(3)
+                            .build()
+            );
+            bannerRepository.save(
+                    Banner.builder()
+                            .image("??/??/bannerImg2.jpg")
+                            .seq(2)
+                            .build()
+            );
+            bannerRepository.save(
+                    Banner.builder()
+                            .image("??/??/bannerImg1.jpg")
+                            .seq(1)
+                            .build()
+            );
         };
     }
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/product/dto/ProductListDto.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/product/dto/ProductListDto.java
@@ -25,13 +25,20 @@ public class ProductListDto {
 
     private Boolean isNew; // 신규 등록 상품 여부
 
+    private Boolean isDiscounted; // 할인 여부
+
+    private Double discountRate; // 할인율
+
 
 
     @QueryProjection
-    public ProductListDto(Long id, String name, Integer price, Boolean isNew) {
+    public ProductListDto(Long id, String name, Integer price, Boolean isNew,
+                          Boolean isDiscounted, Double discountRate) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.isNew = isNew;
+        this.isDiscounted = isDiscounted;
+        this.discountRate = discountRate;
     }
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/product/infrastructure/condition/ProductCondition.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/product/infrastructure/condition/ProductCondition.java
@@ -2,15 +2,18 @@ package com.hummingbird.kr.starbuckslike.product.infrastructure.condition;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class ProductCondition {
 
     private String path; // 카테고리 path
+    private List<Long> childCategoryIds; // 카테고리 자식 Ids
 
     private PriceType priceType; // 상품 가격대
 
-    //이벤트
-    private Long exhibitionId; // 기획전 Id
+
+    private List<Long> exhibitionIds; // 기획전 Ids
 
     private OrderCondition orderCondition;  // 정렬 조건
 

--- a/src/main/java/com/hummingbird/kr/starbuckslike/product/presentation/ProductController.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/product/presentation/ProductController.java
@@ -20,7 +20,7 @@ public class ProductController {
 
     // 상품 리스트 조회 [가격,카테고리]
     @GetMapping("/api/v1/products")
-    public Page<ProductListDto> searchMemberV3(ProductCondition condition, Pageable pageable) {
+    public Page<ProductListDto> searchMemberV1(ProductCondition condition, Pageable pageable) {
         return productSearch.searchProductListPageV1(condition, pageable);
     }
 

--- a/src/test/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/search/BannerSearchTest.java
+++ b/src/test/java/com/hummingbird/kr/starbuckslike/banner/infrastructure/search/BannerSearchTest.java
@@ -1,0 +1,26 @@
+package com.hummingbird.kr.starbuckslike.banner.infrastructure.search;
+
+import com.hummingbird.kr.starbuckslike.banner.dto.BannerDto;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Log4j2
+class BannerSearchTest {
+
+    @Autowired
+    BannerSearch bannerSearch;
+
+    @Test
+    void testFindAllBannerDto(){
+        List<BannerDto> result = bannerSearch.findAllBannerDto();
+        result.forEach(log::info);
+    }
+
+}

--- a/src/test/java/com/hummingbird/kr/starbuckslike/temp/repository/search/CategorySearchTest.java
+++ b/src/test/java/com/hummingbird/kr/starbuckslike/temp/repository/search/CategorySearchTest.java
@@ -19,12 +19,24 @@ class CategorySearchTest {
     void testFindCategoryByDepth(){
         Integer depth = 1;
         List<CategoryListDto> result = categorySearch.findCategoryByDepth(depth);
-
         result.forEach(category -> {
             log.info(
                     "Category id: " + category.getId() +
                             ", Name: " + category.getName() +
                             ", Path: " + category.getPath()
+            );
+        });
+    }
+
+    @Test
+    void testFindAllRootCategory(){
+        List<CategoryListDto> result = categorySearch.findAllRootCategory();
+        result.forEach(category -> {
+            log.info(
+                    "Category id: " + category.getId() +
+                            ", Name: " + category.getName() +
+                            ", Path: " + category.getPath() +
+                            ", image: " + category.getImage()
             );
         });
     }


### PR DESCRIPTION
1.상품 필터링 코드 수정
    - 기획전(단일 id) 으로 해당 기획전에 엮인 상품 조회 →  기획전(여러 기획전 id) 으로 해당 기획전들에 엮인 상품 조회
    - 카테고리 조회 예) 텀블러 카테고리 path로 조회하면 “텀블러” 의 자식인 “텀블러 자식1” , “텀블러 자식2” , “텀블러 자식3” 에 해당하는 상품들이 조회되었다.
    스타벅스 앱에서는 “텀블러” 가 선택된 상태로 , “텀블러 자식1” , “텀블러 자식2” 처럼 자식 카테고리들을 추가로 선택가능하다. 이 경우에 “텀블러 자식3”에 해당
    하는 상품은 조회되지 않도록 작업

2. 배너 entity,dto,repository 기본 작업