### PR TITLE
Feature/40 Cart 

### DIFF
--- a/src/main/generated/com/hummingbird/kr/starbuckslike/category/dto/QCategoryListDto.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/category/dto/QCategoryListDto.java
@@ -13,8 +13,8 @@ public class QCategoryListDto extends ConstructorExpression<CategoryListDto> {
 
     private static final long serialVersionUID = 1515491247L;
 
-    public QCategoryListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> path, com.querydsl.core.types.Expression<String> image) {
-        super(CategoryListDto.class, new Class<?>[]{long.class, String.class, String.class, String.class}, id, name, path, image);
+    public QCategoryListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> path) {
+        super(CategoryListDto.class, new Class<?>[]{long.class, String.class, String.class}, id, name, path);
     }
 
 }

--- a/src/main/generated/com/hummingbird/kr/starbuckslike/category/dto/QMainCategoryListDto.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/category/dto/QMainCategoryListDto.java
@@ -1,0 +1,21 @@
+package com.hummingbird.kr.starbuckslike.category.dto;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.hummingbird.kr.starbuckslike.category.dto.QMainCategoryListDto is a Querydsl Projection type for MainCategoryListDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QMainCategoryListDto extends ConstructorExpression<MainCategoryListDto> {
+
+    private static final long serialVersionUID = 881853110L;
+
+    public QMainCategoryListDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> path, com.querydsl.core.types.Expression<String> image) {
+        super(MainCategoryListDto.class, new Class<?>[]{long.class, String.class, String.class, String.class}, id, name, path, image);
+    }
+
+}
+

--- a/src/main/generated/com/hummingbird/kr/starbuckslike/product/domain/QProduct.java
+++ b/src/main/generated/com/hummingbird/kr/starbuckslike/product/domain/QProduct.java
@@ -37,10 +37,6 @@ public class QProduct extends EntityPathBase<Product> {
 
     public final BooleanPath isDiscounted = createBoolean("isDiscounted");
 
-    public final NumberPath<Integer> maxOrder = createNumber("maxOrder", Integer.class);
-
-    public final NumberPath<Integer> maxPeriod = createNumber("maxPeriod", Integer.class);
-
     public final StringPath name = createString("name");
 
     public final NumberPath<Integer> price = createNumber("price", Integer.class);

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/application/CartService.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/application/CartService.java
@@ -1,5 +1,32 @@
 package com.hummingbird.kr.starbuckslike.cart.application;
 
+import com.hummingbird.kr.starbuckslike.cart.dto.AddCartItemDto;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
 public interface CartService {
-    //void addCart()
+
+    // 장바구니 아이템 추가 [상품디테일 페이지의 장바구니 추가버튼]
+    @Transactional
+    public void addCartItem(AddCartItemDto addCartItemDto);
+
+    // todo 장바구니 옵션 증가,감소
+
+
+    // 장바구니 단건 삭제
+    @Transactional
+    public void removeCartItem(Long cartId);
+
+    // 장바구니 선택 삭제
+    @Transactional
+    public void removeCartItems(List<Long> cartIds, String userUid);
+
+    // 장바구니 전체 삭제
+    @Transactional
+    public void removeAllCartItem(String userUid);
+
+
+
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/application/CartServiceImpl.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/application/CartServiceImpl.java
@@ -1,0 +1,91 @@
+package com.hummingbird.kr.starbuckslike.cart.application;
+
+import com.hummingbird.kr.starbuckslike.cart.domain.Cart;
+import com.hummingbird.kr.starbuckslike.cart.dto.AddCartItemDto;
+import com.hummingbird.kr.starbuckslike.cart.infrastructure.CartRepository;
+import com.hummingbird.kr.starbuckslike.cart.infrastructure.search.CartSearch;
+import com.hummingbird.kr.starbuckslike.product.domain.ProductOption;
+import com.hummingbird.kr.starbuckslike.product.infrastructure.ProductOptionRepository;
+import com.hummingbird.kr.starbuckslike.product.infrastructure.ProductRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class CartServiceImpl implements CartService{
+
+    private final CartSearch cartSearch;
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final ProductOptionRepository productOptionRepository;
+
+    /**
+     * 상품디테일에서 장바구니 추가 기능
+     * 1. 회원이 담을 수 있는 장바구니 아이템은 20개 까지다 (선택 수량 아님)
+     * 2. 최소 1개 이상의 수량을 선택해야 한다
+     * 3. 아직 담지 않은 상품이면 신규 장바구니 아이템 생성, 아니라면 선택한수량을 기존 수량에 더해준다
+     * 4. 신규 장바구니는 카운트 쿼리 결과 0 , 기존 장바구니는 1 로 판단한다. 그 외의 경우는 에러
+     * @param addCartItemDto
+     * @author 허정현
+     */
+    @Override
+    public void addCartItem(AddCartItemDto addCartItemDto) {
+        // 회원이 담을 수 있는 장바구니 아이템은 20개 까지다
+        Long totalCount = cartSearch.findCartItemCountByMember(addCartItemDto.getMemberUID());
+        if(totalCount >= 20)
+            throw new IllegalStateException("장바구니에는 최대 20종류의 상품까지 담을 수 있습니다.");
+        // 최소 수량 검증
+        if(addCartItemDto.getQty() < 1)
+            throw new IllegalStateException("장바구니에 담길 상품의 최소 수량은 1개 이상이어야 합니다.");
+        // 이미 장바구니에 있는 상품인지 확인
+        Long cartOptionCount =
+                cartSearch.findCartOptionCount(addCartItemDto.getMemberUID(), addCartItemDto.getOptionId());
+        // 처음 장바구니에 담는 상품
+        if(cartOptionCount == 0L){
+            ProductOption selectOption = productOptionRepository
+                    .findById(addCartItemDto.getOptionId())
+                    .orElseThrow(() -> new NoSuchElementException("상품 옵션을 찾을 수 없습니다. " ));
+            // 장바구니 객체 생성
+            Cart newCart = Cart.builder()
+                    .productOption(selectOption)
+                    .userUid(addCartItemDto.getMemberUID())
+                    .qty(addCartItemDto.getQty())
+                    .inputData(addCartItemDto.getInputData())
+                    .build();
+            cartRepository.save(newCart); // 신규 장바구니 상품 저장 완료
+        }
+        // 이미 장바구니에 담긴 옵션, 수량만 더해주면 됨
+        else if(cartOptionCount == 1L){
+            Cart findCart = cartSearch.findCartOption(addCartItemDto.getMemberUID(), addCartItemDto.getOptionId());
+            findCart.addOptionQty(addCartItemDto.getQty()); // 수량 더해줌
+        }
+        else{
+            // 같은 사람의 장바구니에 같은 상품이 2개가 담겼다. 문제있음 에러처리
+            throw new IllegalStateException("동일한 상품이 장바구니에 담길 수 없습니다.");
+        }
+    }
+
+    @Override
+    public void removeCartItem(Long cartId) {
+        cartRepository.deleteById(cartId);
+    }
+
+    @Override
+    public void removeCartItems(List<Long> cartIds, String userUid) {
+        cartRepository.removeCartItems(cartIds,userUid);
+    }
+
+    @Override
+    public void removeAllCartItem(String userUid) {
+        cartRepository.removeAllCartItem(userUid);
+    }
+
+}

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/domain/Cart.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/domain/Cart.java
@@ -35,9 +35,25 @@ public class Cart extends BaseEntity {
     private ProductOption productOption; // 상품 옵션
 
     @Column(name = "qty" , nullable = false)
-    private Integer qty; // 수량
+    private Integer qty = 1; // 수량
 
     @Column(name = "input_data" , nullable = true , length = 80)
     private String inputData; // 각인정보 같은 입력 데이터
+
+    // 장바구니 아이템 추가
+    public void addOptionQty(Integer addQty) {
+        this.qty += addQty;
+    }
+    // 장바구니 아이템 수량 증가
+    public void increaseCartItemQuantity() {
+        this.qty++;
+    }
+    // 장바구니 아이템 수량 감소
+    public void decreaseCartItemQuantity() {
+        if(this.qty <= 1)
+            throw new IllegalStateException("최소 선택수량은 1개 이상입니다.");
+        this.qty--;
+
+    }
 
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/dto/AddCartItemDto.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/dto/AddCartItemDto.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AddCartItem {
+public class AddCartItemDto {
 
     private String memberUID; // 유저 정보
 
@@ -22,7 +22,7 @@ public class AddCartItem {
 
     private Integer qty = 1; // 상품 옵션 선택 수량
 
-
+    private String inputData; // 각인 옵션상품의 경우 입력 데이터
 
 
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/infrastructure/CartRepository.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/infrastructure/CartRepository.java
@@ -2,7 +2,26 @@ package com.hummingbird.kr.starbuckslike.cart.infrastructure;
 
 import com.hummingbird.kr.starbuckslike.cart.domain.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CartRepository extends JpaRepository<Cart,Long> {
 
+
+    // 장바구니 아이템 선택 삭제
+    @Modifying(clearAutomatically = true) // 벌크쿼리 영속성 컨텍스트 초기화
+    @Query("delete from Cart c" +
+            " where c.id in :cartIds" +
+            " and c.userUid = :userUid")
+    void removeCartItems(@Param("cartIds") List<Long> cartIds, @Param("userUid") String userUid);
+
+
+    // 회원의 전체 장바구니 삭제
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Cart c" +
+            " where c.userUid = :userUid")
+    void removeAllCartItem(@Param("userUid") String userUid);
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/infrastructure/search/CartSearch.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/infrastructure/search/CartSearch.java
@@ -1,6 +1,9 @@
 package com.hummingbird.kr.starbuckslike.cart.infrastructure.search;
 
+import com.hummingbird.kr.starbuckslike.cart.domain.Cart;
 import com.hummingbird.kr.starbuckslike.cart.dto.CartListDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -8,7 +11,18 @@ import java.util.List;
 @Repository
 public interface CartSearch {
 
+
     // 회원 uuid로 회원 장바구니 리스트 조회
     List<CartListDto> findCartListDtoByUserUid(String userUid);
+
+    // 회원 장바구니에 담은 상품 조회
+    Cart findCartOption(String userUid, Long optionId);
+
+
+    // 회원 장바구니에  상품옵션 담았는지 확인 [ 1 : 이미 존재 , 0 : 없음  ]
+    Long findCartOptionCount(String userUid, Long optionId);
+
+    // 회원의 장바구니에 삼은 상품들의 숫자 (20개로 제한)
+    Long findCartItemCountByMember(String userUid);
 
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/cart/infrastructure/search/CartSearchImpl.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/cart/infrastructure/search/CartSearchImpl.java
@@ -1,12 +1,57 @@
 package com.hummingbird.kr.starbuckslike.cart.infrastructure.search;
 
+import com.hummingbird.kr.starbuckslike.cart.domain.Cart;
+import com.hummingbird.kr.starbuckslike.cart.domain.QCart;
 import com.hummingbird.kr.starbuckslike.cart.dto.CartListDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-public class CartSearchImpl implements CartSearch{
+import static com.hummingbird.kr.starbuckslike.cart.domain.QCart.cart;
+
+@Repository
+public class CartSearchImpl implements CartSearch {
+
+    private final JPAQueryFactory queryFactory;
+    public CartSearchImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
     @Override
     public List<CartListDto> findCartListDtoByUserUid(String userUid) {
         return null;
     }
+
+    @Override
+    public Cart findCartOption(String userUid, Long optionId) {
+        return queryFactory
+                .selectFrom(cart)
+                .where(
+                        cart.userUid.eq(userUid).and(cart.productOption.id.eq(optionId))
+                )
+                .fetchOne();
+    }
+
+    @Override
+    public Long findCartOptionCount(String userUid, Long optionId) {
+        return queryFactory
+                .select(cart.count())
+                .from(cart)
+                .where(
+                        cart.userUid.eq(userUid).and(cart.productOption.id.eq(optionId))
+                )
+                .fetchOne();
+    }
+
+    @Override
+    public Long findCartItemCountByMember(String userUid) {
+        return queryFactory
+                .select(cart.count())
+                .from(cart)
+                .where( cart.userUid.eq(userUid) )
+                .fetchOne();
+    }
+
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/dto/MainCategoryListDto.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/dto/MainCategoryListDto.java
@@ -8,19 +8,20 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 @NoArgsConstructor
-public class CategoryListDto {
+public class MainCategoryListDto {
     private Long id; // 카테고리 id
 
     private String name; // 카테고리 이름
 
     private String path; // 카테고리 경로
 
+    private String image; // 카테고리 이미지 경로
 
     @QueryProjection
-    public CategoryListDto(Long id, String name, String path) {
+    public MainCategoryListDto(Long id, String name, String path, String image) {
         this.id = id;
         this.name = name;
         this.path = path;
+        this.image = image;
     }
-
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearch.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearch.java
@@ -1,6 +1,7 @@
 package com.hummingbird.kr.starbuckslike.category.infrastructure.search;
 
 import com.hummingbird.kr.starbuckslike.category.dto.CategoryListDto;
+import com.hummingbird.kr.starbuckslike.category.dto.MainCategoryListDto;
 
 import java.util.List;
 
@@ -9,5 +10,5 @@ public interface CategorySearch {
     List<CategoryListDto> findCategoryByDepth(Integer depth);
 
     // 최상위 부모 카테고리만 출력
-    List<CategoryListDto> findAllRootCategory();
+    List<MainCategoryListDto> findAllRootCategory();
 }

--- a/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearchImpl.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/category/infrastructure/search/CategorySearchImpl.java
@@ -1,7 +1,9 @@
 package com.hummingbird.kr.starbuckslike.category.infrastructure.search;
 
 import com.hummingbird.kr.starbuckslike.category.dto.CategoryListDto;
+import com.hummingbird.kr.starbuckslike.category.dto.MainCategoryListDto;
 import com.hummingbird.kr.starbuckslike.category.dto.QCategoryListDto;
+import com.hummingbird.kr.starbuckslike.category.dto.QMainCategoryListDto;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -28,7 +30,7 @@ public class CategorySearchImpl implements CategorySearch {
     @Override
     public List<CategoryListDto> findCategoryByDepth(Integer depth) {
         return queryFactory
-                .select(new QCategoryListDto(category.id, category.name, category.path, category.image))
+                .select(new QCategoryListDto(category.id, category.name, category.path))
                 .from(category)
                 .where(category.depth.eq(depth))
                 .orderBy(category.id.asc())
@@ -36,9 +38,9 @@ public class CategorySearchImpl implements CategorySearch {
     }
 
     @Override
-    public List<CategoryListDto> findAllRootCategory() {
+    public List<MainCategoryListDto> findAllRootCategory() {
         return queryFactory
-                .select(new QCategoryListDto(category.id, category.name, category.path, category.image))
+                .select(new QMainCategoryListDto(category.id, category.name, category.path, category.image))
                 .from(category)
                 .where(
                         rootCondition() // 최상위 부모 카테고리만 검색

--- a/src/main/java/com/hummingbird/kr/starbuckslike/config/LoadTestData.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/config/LoadTestData.java
@@ -127,8 +127,8 @@ public class LoadTestData {
                     .shortDescription("스탠리 텀블러입니다.")
                     .fullDescription("<p>스탠리 텀블러 상품 상세</p>")
                     .status(SalesStatus.AVAILABLE)
-                    .maxOrder(5)
-                    .maxPeriod(30)
+                    //.maxOrder(5)
+                    //.maxPeriod(30)
                     .category(tumbler)
                     .build()
             );
@@ -141,8 +141,6 @@ public class LoadTestData {
                     .shortDescription("스탠리 스테인리스 텀블러 압나더.")
                     .fullDescription("<p>스탠리 스테인리스 텀블러 상품 상세</p>")
                     .status(SalesStatus.AVAILABLE)
-                    .maxOrder(3)
-                    .maxPeriod(30)
                     .category(stainlessTumbler)
                     .build()
             );
@@ -155,8 +153,6 @@ public class LoadTestData {
                     .shortDescription("스탠리 고급 스테인리스 텀블러 입니다")
                     .fullDescription("<p>스탠리 고급 스테인리스 텀블러 상품 상세</p>")
                     .status(SalesStatus.AVAILABLE)
-                    .maxOrder(2)
-                    .maxPeriod(15)
                     .category(highStainlessTumbler)
                     .build()
             );
@@ -168,8 +164,7 @@ public class LoadTestData {
                     .shortDescription("펭귄 컵 입니다")
                     .fullDescription("<p>펭귄 컵 상품 상세</p>")
                     .status(SalesStatus.AVAILABLE)
-                    .maxOrder(2)
-                    .maxPeriod(15)
+
                     .category(cup)
                     .build()
             );
@@ -181,8 +176,6 @@ public class LoadTestData {
                     .shortDescription("펭귄 유리 컵 입니다")
                     .fullDescription("<p>펭귄 유리 컵 상품 상세</p>")
                     .status(SalesStatus.AVAILABLE)
-                    .maxOrder(2)
-                    .maxPeriod(15)
                     .category(glassCup)
                     .build()
             );

--- a/src/main/java/com/hummingbird/kr/starbuckslike/product/domain/Product.java
+++ b/src/main/java/com/hummingbird/kr/starbuckslike/product/domain/Product.java
@@ -45,11 +45,11 @@ public class Product extends BaseEntity {
     private SalesStatus status; // 판매 상태 : AVAILABLE, DISCONTINUED , HIDDEN
 
 
-    @Column(name = "max_order", nullable = false)
-    private Integer maxOrder; // 최대 주문 가능 수량
-
-    @Column(name = "max_period", nullable = false)
-    private Integer maxPeriod; // 최대 주문 가능 수량 정책 일
+//    @Column(name = "max_order", nullable = false)
+//    private Integer maxOrder; // 최대 주문 가능 수량
+//
+//    @Column(name = "max_period", nullable = false)
+//    private Integer maxPeriod; // 최대 주문 가능 수량 정책 일
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")

--- a/src/test/java/com/hummingbird/kr/starbuckslike/cart/domain/CartTest.java
+++ b/src/test/java/com/hummingbird/kr/starbuckslike/cart/domain/CartTest.java
@@ -1,0 +1,68 @@
+package com.hummingbird.kr.starbuckslike.cart.domain;
+
+import com.hummingbird.kr.starbuckslike.product.domain.Product;
+import com.hummingbird.kr.starbuckslike.product.domain.ProductOption;
+import com.hummingbird.kr.starbuckslike.product.infrastructure.ProductOptionRepository;
+import com.hummingbird.kr.starbuckslike.product.infrastructure.ProductRepository;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@Log4j2
+@SpringBootTest
+class CartTest {
+    @Autowired
+    ProductOptionRepository productOptionRepository;
+
+
+    @Test // 장바구니 추가 테스트
+    void addOptionQty(){
+        Optional<ProductOption> optionalOption = productOptionRepository.findById(1L);
+        ProductOption productOption = optionalOption.orElseThrow();
+        Cart newCart = Cart.builder()
+                .productOption(productOption)
+                .userUid("testUid")
+                .qty(5)
+                .build();
+        newCart.addOptionQty(3);
+        org.assertj.core.api.Assertions.assertThat(8).isEqualTo(newCart.getQty());
+    }
+    @Test // 장바구니 아이템 선택수량 증가 테스트
+    void increaseCartItemQuantity(){
+        Optional<ProductOption> optionalOption = productOptionRepository.findById(1L);
+        ProductOption productOption = optionalOption.orElseThrow();
+        Cart newCart = Cart.builder()
+                .productOption(productOption)
+                .userUid("testUid")
+                .qty(5)
+                .build();
+        newCart.increaseCartItemQuantity();
+        org.assertj.core.api.Assertions.assertThat(6).isEqualTo(newCart.getQty());
+    }
+
+    @Test // 장바구니 아이템 선택수량 감소 테스트
+    void decreaseCartItemQuantity(){
+        Optional<ProductOption> optionalOption = productOptionRepository.findById(1L);
+        ProductOption productOption = optionalOption.orElseThrow();
+        Cart newCart = Cart.builder()
+                .productOption(productOption)
+                .userUid("testUid")
+                .qty(2)
+                .build();
+        newCart.decreaseCartItemQuantity();
+        org.assertj.core.api.Assertions.assertThat(1).isEqualTo(newCart.getQty());
+        assertThrows(IllegalStateException.class, () -> {
+            newCart.decreaseCartItemQuantity();
+        });
+
+    }
+
+
+}

--- a/src/test/java/com/hummingbird/kr/starbuckslike/temp/repository/search/CategorySearchTest.java
+++ b/src/test/java/com/hummingbird/kr/starbuckslike/temp/repository/search/CategorySearchTest.java
@@ -1,6 +1,7 @@
 package com.hummingbird.kr.starbuckslike.temp.repository.search;
 
 import com.hummingbird.kr.starbuckslike.category.dto.CategoryListDto;
+import com.hummingbird.kr.starbuckslike.category.dto.MainCategoryListDto;
 import com.hummingbird.kr.starbuckslike.category.infrastructure.search.CategorySearch;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class CategorySearchTest {
 
     @Test
     void testFindAllRootCategory(){
-        List<CategoryListDto> result = categorySearch.findAllRootCategory();
+        List<MainCategoryListDto> result = categorySearch.findAllRootCategory();
         result.forEach(category -> {
             log.info(
                     "Category id: " + category.getId() +


### PR DESCRIPTION
장바구니 서비스  작업 
 -  장바구니 아이템 추가 [상품디테일 페이지의 장바구니 추가버튼]
 - 장바구니 옵션 증가,감소 (진행예정) 
 - 장바구니 선택 삭제
 - 장바구니 전체 삭제
 
장바구니 레포지토리  작업 
 - 회원 uuid로 회원 장바구니 리스트 조회
 - 회원 장바구니에 담은 상품 조회
 - 회원 장바구니에 상품옵션을 담았는지 확인
 - 회원의 장바구니에 삼은 상품들의 숫자 (20개로 제한)
 -  장바구니 아이템 선택 삭제
 - 회원의 전체 장바구니 삭제