### PR TITLE
Update dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,24 @@ updates:
     commit-message:
       prefix: "fix(dependencies)"
       include: "scope"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    target-branch: "dev"
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "fix(security)"
+      include: "scope"
+    allow:
+      - dependency-type: "direct:production"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yaml` file to enhance dependency management and security practices. The most important changes are the addition of new configuration settings for Gradle dependencies and the grouping of all dependencies.

Enhancements to dependency management:

* Added a new configuration for Gradle dependencies with a daily update schedule, a limit of 10 open pull requests, targeting the `dev` branch, and an automatic rebase strategy. This configuration also specifies that only direct production dependencies are allowed.

* Introduced a grouping mechanism for all dependencies using patterns to match any dependency. This grouping is applied to both the existing and new configurations.